### PR TITLE
adding errors in active_model 7

### DIFF
--- a/lib/active_model/validations/type_validator.rb
+++ b/lib/active_model/validations/type_validator.rb
@@ -18,7 +18,7 @@ module ActiveModel
           allowed_classes = classes.to_sentence two_words_connector: " or ",
                                                 last_word_connector: ", or "
 
-          record.errors[attribute] << (options[:message] || "must be a #{allowed_classes}")
+          record.errors.add(attribute, (options[:message] || "must be a #{allowed_classes}"))
         end
       end
     end

--- a/lib/ph_model/version.rb
+++ b/lib/ph_model/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module PhModel
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end


### PR DESCRIPTION
Fixes errors not being added to the `ActiveModel::Errors` object in version 7+, thus validating invalid objects. 